### PR TITLE
Don't depend on R 4.1.0

### DIFF
--- a/R/find_equivalents.R
+++ b/R/find_equivalents.R
@@ -16,7 +16,7 @@ find_equivalent_nodes <- function(node, dates, graph) {
     unreachable = FALSE
   )[["order"]]
 
-  result <- lapply(dates, \(date) {
+  result <- lapply(dates, function(date) {
     result_nodes <- related_nodes[
       date >= related_nodes$validFrom &
         (date < related_nodes$validTo | is.na(related_nodes$validTo))


### PR DESCRIPTION
The \ shorthand for function() was introduced in 4.1.0. Since we don't depend on this R version it is better to use function().